### PR TITLE
Виправлено ReferenceError: apiUrl is not defined (v2.6)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 Формат заснований на [Keep a Changelog](https://keepachangelog.com/uk/1.0.0/),
 і цей проєкт дотримується [Semantic Versioning](https://semver.org/lang/uk/).
 
+## [2.6] - 2026-02-27
+
+### Виправлено
+- **ReferenceError: apiUrl is not defined**: додано визначення функції `apiUrl(path)` в index.html (виклики були додані в 2.5, сама функція не була оголошена)
+
 ## [2.5] - 2026-02-27
 
 ### Додано

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 
   <script>
     // Версія коду - оновлюється після кожної зміни
-    const VERSION = '2.5';
+    const VERSION = '2.6';
     
     // fetch з таймаутом (мс), щоб не чекати надто довго при недоступному API
     const API_FETCH_TIMEOUT_MS = 15000;
@@ -121,6 +121,10 @@
         hour12: false
       });
       return parseInt(ukraineTime, 10);
+    }
+
+    function apiUrl(path) {
+      return path;
     }
 
     const titleEl = document.querySelector('.title');


### PR DESCRIPTION
- Додано визначення функції apiUrl(path) в index.html
- Оновлено версію до 2.6, запис у CHANGELOG

Made-with: Cursor